### PR TITLE
infer regress or classify in explain_instance

### DIFF
--- a/lemon/explainer.py
+++ b/lemon/explainer.py
@@ -166,9 +166,19 @@ class LemonExplainer(object):
       prediction = predict_fn(np.array(instance).reshape(1,-1))
       y_transfer = predict_fn(X_transfer)
 
+    if y_transfer.ndim==1: # Single-output model
+      prediction = prediction[..., None]
+      y_transfer = y_transfer[..., None]
+
+    # infer model type
     if labels is None:
-      prediction_index = np.argmax(prediction)
-      labels = (prediction_index,)
+      if prediction.sum()==1:
+        # outputs probabilities: classification model, explain predicted class
+        prediction_index = np.argmax(prediction)
+        labels = (prediction_index,)
+      else:
+        # other: (multi-output) regression, explain all targets
+        labels = tuple([*np.arange(prediction.shape[-1])])
 
     for index in self.categorical_features:
       # single one-hot encoded feature for categorical


### PR DESCRIPTION
In Lemonexplainer.explain_instance, predictions & y_transfer are expanded with an empty dim on the right for models with singular outputs. Distinguishing between classifiers & regressors by checking ndim>1 might not be so general since the regressor could still be a multi-output regressor. So I choose to use the sum over the prediction, if this equals 1 assume we're dealing with a classifier and the predicted class label is explained. Otherwise, regression is assumed and it defaults to all outputs being explained.

I added a test for a multioutput regressor using an sklearn LinearRegression, I copied the TestExplainerCategorical class and changed it slightly using the tiny dataset 'linnerud' (20 instances, 3 features, 3 targets).

I tried to find the cause of the SettingWithCopyWarning pandas is throwing in the tests when assigning values to a dataframe using dataframe.loc[:, col_indexer] but couldn't find the reason why it's raising that error.